### PR TITLE
$suffix auf null gesetzt

### DIFF
--- a/lib/one_level_no_suffix.php
+++ b/lib/one_level_no_suffix.php
@@ -1,6 +1,8 @@
 <?php
 class one_level_no_suffix extends rex_yrewrite_scheme
 {
+    protected $suffix = null;
+    
     public function appendCategory($path, rex_category $cat, rex_yrewrite_domain $domain)
     {
         return $path;


### PR DESCRIPTION
rex_yrewrite_scheme bekam eine Methode getSuffix() damit andere AddOns darauf zugreifen können. Daher muss das $suffix notiert werden, da ansonsten das $suffix aus der Elternklasse fälschlicherweise zurückgegeben wird.
